### PR TITLE
Bonjour support 

### DIFF
--- a/bin/kano-vnc
+++ b/bin/kano-vnc
@@ -49,17 +49,21 @@ vnc_start() {
 
     $VNC_CMDLINE > /dev/null 2>&1
     if test $? = 0; then
+	
         # Get Ethernet ip
         IP=`/sbin/ifconfig eth0 | grep inet | awk '{print $2}' | cut -d':' -f2`
 
         # Get wlan0 IP if needed
         if [ -z $IP ]; then
             IP=`/sbin/ifconfig wlan0 | grep inet | awk '{print $2}' | cut -d':' -f2`
-        fi
+        fi        # Get hostname
+        HOSTNAME=`hostname` 
 
         # Confirmation message
         if [ ${DISPLAY} ]; then
-            kano-dialog title="The VNC Server was enabled" description="IP is $IP$VNC_DISPLAY (TCP port 5900)"
+            kano-dialog title="The VNC Server was enabled" description="Hostname is $HOSTNAME.local$VNC_DISPLAY 
+IP is $IP(TCP port 5900)
+"
         fi
     else
         # Error message

--- a/debian/control
+++ b/debian/control
@@ -7,7 +7,7 @@ Build-Depends: debhelper (>=9.0.0)
 
 Package: kano-vnc
 Architecture: all
-Depends: ${misc:Depends}, x11vnc, libkdesk-dev
+Depends: ${misc:Depends}, x11vnc, libkdesk-dev, kano-settings (>=2.0-3)
 Suggests: kano-profile
 Description: Simple VNC server wrapper
  Allows really simple toggling of the tightvncserver.

--- a/share/vncglobals
+++ b/share/vncglobals
@@ -14,4 +14,4 @@ VNC_DISPLAY=":0"
 SHINCOMING="/usr/share/kano-vnc/vncincoming"
 VNCAPP="/usr/bin/x11vnc"
 
-VNC_CMDLINE="$VNCAPP -rfbauth $PASS_FILE -display $VNC_DISPLAY -no6 -noipv6 -dontdisconnect -forever -shared -nolookup -ungrabboth -accept \"$SHINCOMING\" -N -bg"
+VNC_CMDLINE="$VNCAPP -rfbauth $PASS_FILE -avahi -display $VNC_DISPLAY -no6 -noipv6 -dontdisconnect -forever -shared -nolookup -ungrabboth -accept \"$SHINCOMING\" -N -bg"


### PR DESCRIPTION
This PR: 
Adds the avahi option to x11vnc.
Changes kano-vnc to display hostname as well as IP address, since we are now advertising a hostname.
We still display an IP as not all windows machines will support bonjour.
This is for https://github.com/KanoComputing/peldins/issues/1945

One issue is that it displays the wrong IP address if you are in powerup-kit mode because normally ethernet overrides the wlan IP interface, but in powerup-kitmode ethernet is used for the pi1 only.