### PR TITLE
Fix for hourglass active for too long

### DIFF
--- a/icon/vnc.app
+++ b/icon/vnc.app
@@ -10,5 +10,6 @@
 
   "packages": [],
   "dependencies": ["kano-vnc"],
-  "launch_command": "/usr/bin/kano-vnc switch"
+  "launch_command": "/usr/bin/kano-vnc switch",
+  "StartupNotify": "false"
 }


### PR DESCRIPTION
 * This fix tells LXDE to not start the hourglass when launched
   from the taskbar start menu. kano-vnc provides its own.

cc @alex5imon @pazdera 
