### PR TITLE
i18n hooks and Japanese translation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@
 *.swo
 .DS_store
 *~
+*.mo
+po/messages.pot

--- a/TRANSLATION.md
+++ b/TRANSLATION.md
@@ -1,0 +1,61 @@
+# Translation
+
+Translation files are found in the `po/` directory.
+
+## i18n not released yet
+
+Kano OS is not fully i18n-aware and locales are not installed for end users, yet. You can translate this application, but as of now, users will still see the default English message strings.
+
+## How to add a new translation
+
+In this example, we're going to add a French translation:
+
+    # install your target locale `fr_FR.utf8` with:
+    sudo dpkg-reconfigure locales
+    
+    cd po/
+    # create messages.pot
+    make messages
+    
+    # create fr.po from messages.pot:
+    msginit -l fr_FR.utf8
+    
+    # now use your favourite editor to translate fr.po
+    
+    # build locale files:
+    make
+    
+    cd ..
+
+    # when testing, make sure LC_ALL is set to your locale e.g.
+    LC_ALL=fr_FR.utf8
+
+## How to make sure your code is i18n-aware
+
+Add the gettext `_()` macro to all the user-visible message strings in your Python. List the Python source files that contain message strings in `PYPOTFILES`.
+
+If you added new message strings or made changes to existing ones, do `make messages` to keep the template file up-to-date.
+
+After that, merge the existing translations with `make update` and ask your translators to update their translations.
+
+## gettext explained (in 20 seconds)
+
+* User-visible strings in the source are marked with a macro of your choice. Usually, it's `_()`.
+* `xgettext` extracts these message strings from your sources and puts them into a template file.
+* This template file, usually named `messages.pot`, contains all user-visible strings of the project, but no translations.
+* Translators use `msginit` to copy the template file into a new *portable object* file for their language (explained above).
+* The translations are put into `<lang>.po`. It's a plain-text file format, you can use any text editor.
+* More convenient, specialized `.po`-editors and web-based tools such as Pootle exist, as well.
+* If your template file changes, use `msgmerge` to merge your existing translations with the new template, then re-translate the updated messages. Beware of `msgmerge`'s "fuzzy" matches.
+* `msgfmt` converts a `.po` file into a binary *message object* file.
+* You don't link these `.mo` files with your application binary.
+* The `.mo` files are bundled alongside with your software as part of the distribution package.
+* During installation, the `.mo` files are copied into the system's locale directory, usually `/usr/share/locale`.
+* On startup, your application will look for the message object file that it needs for the current system locale.
+* The locale even allows you to provide region-specific translations, e.g. "colour" for en_UK vs "color" for en_US.
+* At runtime, all user-visible strings are being replaced with the translations.
+* If no message object was found for the system locale, the original strings will be shown. 
+
+## To-Do
+
+Pootle or Transifex integration.

--- a/bin/kano-vnc
+++ b/bin/kano-vnc
@@ -10,6 +10,9 @@
 
 . /usr/share/kano-vnc/vncglobals
 
+. gettext.sh
+export TEXTDOMAIN="make-snake"
+
 vnc_status() {
     # returns 1 if VNC is running, 0 if stopped
     if [ "`pidof x11vnc`" != "" ]; then
@@ -51,24 +54,24 @@ vnc_start() {
     if test $? = 0; then
 	
         # Get Ethernet ip
-        IP=`/sbin/ifconfig eth0 | grep inet | awk '{print $2}' | cut -d':' -f2`
+        IP=`LANG=en_US /sbin/ifconfig eth0 | grep inet | awk '{print $2}' | cut -d':' -f2`
 
         # Get wlan0 IP if needed
         if [ -z $IP ]; then
-            IP=`/sbin/ifconfig wlan0 | grep inet | awk '{print $2}' | cut -d':' -f2`
+            IP=`LANG=en_US /sbin/ifconfig wlan0 | grep inet | awk '{print $2}' | cut -d':' -f2`
         fi        # Get hostname
         HOSTNAME=`hostname` 
 
         # Confirmation message
         if [ ${DISPLAY} ]; then
-            kano-dialog title="The VNC Server was enabled" description="Hostname is $HOSTNAME.local$VNC_DISPLAY 
-IP is $IP(TCP port 5900)
-"
+            kano-dialog title="`gettext "The VNC Server was enabled"`" description="`eval_gettext "Hostname is \\\$HOSTNAME.local\\\$VNC_DISPLAY 
+IP is \\\$IP(TCP port 5900)
+"`"
         fi
     else
         # Error message
         if [ ${DISPLAY} ]; then
-            kano-dialog title='Error!' description='Something went wrong'
+            kano-dialog title="`gettext "Error!"`" description="`gettext "Something went wrong"`"
         fi
         return 1
     fi
@@ -89,7 +92,7 @@ vnc_stop() {
     # Disable the server
     pkill -9 x11vnc >/dev/null 2>&1
     if [ ${DISPLAY} ]; then
-        kano-dialog title='The VNC Server was disabled'
+        kano-dialog title="`gettext "The VNC Server was disabled"`"
     fi
 
     # Remove .vnc folder
@@ -104,7 +107,7 @@ password_prompt() {
             # Ask for password using the GUI
             kdesk-hourglass-app "kano-dialog"
 
-            PASSWORD=$(kano-dialog title="Create a VNC password" description="Make it 6 to 8 characters long"\
+            PASSWORD=$(kano-dialog title="`gettext "Create a VNC password"`" description="`gettext "Make it 6 to 8 characters long"`"\
                    entry=hidden button=OK,color:green button=CANCEL,return_value:1,color:red\
                    global_style=True)
 
@@ -116,7 +119,7 @@ password_prompt() {
             elif [ ${#PASSWORD} -ge 6 ] && [ ${#PASSWORD} -le 8 ]; then
                 break;
             else
-                kano-dialog title="You did not enter a valid password" description="Try again"
+                kano-dialog title="`gettext "You did not enter a valid password"`" description="`gettext "Try again"`"
             fi
         done
         # return empty password

--- a/bin/kano-vnc
+++ b/bin/kano-vnc
@@ -11,7 +11,7 @@
 . /usr/share/kano-vnc/vncglobals
 
 . gettext.sh
-export TEXTDOMAIN="make-snake"
+export TEXTDOMAIN="kano-vnc"
 
 vnc_status() {
     # returns 1 if VNC is running, 0 if stopped

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,21 +1,20 @@
-
 kano-vnc (1.1-4) unstable; urgency=low
 
   * Updated documentation, and clean code to make it ready for public repo
 
- -- Team Kano <dev@kano.me>  Wed, Feb 04 15:04:00 2015 +0200
+ -- Team Kano <dev@kano.me>  Wed, 04 Feb 2015 15:04:00 +0200
 
 kano-vnc (1.1-3) unstable; urgency=low
 
   * Pre-release New Kano notification messages when remote clients connect to VNC
 
- -- Team Kano <dev@kano.me>  Fri, Oct 17 17:04:00 2014 +0200
+ -- Team Kano <dev@kano.me>  Fri, 17 Oct 2014 17:04:00 +0200
 
 kano-vnc (1.1-2) unstable; urgency=low
 
   * Pre-release kano-vnc now gives a command line list of management options
 
- -- Team Kano <dev@kano.me>  Thu, Oct 16 12:26:04 2014 +0200
+ -- Team Kano <dev@kano.me>  Thu, 16 Oct 2014 12:26:04 +0200
 
 kano-vnc (1.1-1) unstable; urgency=low
 

--- a/debian/control
+++ b/debian/control
@@ -3,11 +3,11 @@ Maintainer: Team Kano <dev@kano.me>
 Section: utils
 Priority: optional
 Standards-Version: 3.9.4
-Build-Depends: debhelper (>=9.0.0)
+Build-Depends: debhelper (>=9.0.0), gettext
 
 Package: kano-vnc
 Architecture: all
-Depends: ${misc:Depends}, x11vnc, libkdesk-dev, kano-settings (>=2.0-3)
+Depends: ${misc:Depends}, x11vnc, libkdesk-dev, kano-settings (>=2.0-3), gettext
 Suggests: kano-profile
 Description: Simple VNC server wrapper
  Allows really simple toggling of the tightvncserver.

--- a/debian/install
+++ b/debian/install
@@ -3,3 +3,5 @@ share/* usr/share/kano-vnc
 
 icon/vnc.app usr/share/applications/
 icon/vnc.png usr/share/icons/Kano/66x66/apps/
+
+locale/* usr/share/locale/

--- a/debian/rules
+++ b/debian/rules
@@ -1,4 +1,5 @@
 #!/usr/bin/make -f
 
 %:
+	cd po && make
 	dh $@

--- a/po/Makefile
+++ b/po/Makefile
@@ -1,0 +1,36 @@
+APPNAME=kano-vnc
+ORG="Kano Computing Ltd."
+
+MSGLANGS=$(notdir $(wildcard *po))
+MSGOBJS=$(addprefix ../locale/,$(MSGLANGS:.po=/LC_MESSAGES/$(APPNAME).mo))
+
+.PHONY: clean_locales messages
+
+build: $(MSGOBJS)
+
+update: $(MSGLANGS)
+
+clean_locales:
+	rm -rf ../locale
+
+clean: clean_locales
+	rm -f messages.pot
+
+define run-xgettext
+xgettext --force-po -o messages.pot -L Shell --keyword=eval_gettext ../bin/kano-vnc ../share/vncincoming \
+    --package-name=$(APPNAME) --copyright-holder=$(ORG)
+endef
+
+messages:
+	$(run-xgettext)
+
+messages.pot:
+	$(run-xgettext)
+
+%.po: messages.pot
+	msgmerge -N -U $*.po messages.pot
+	touch $*.po
+
+../locale/%/LC_MESSAGES/$(APPNAME).mo: clean_locales
+	mkdir -p $(dir $@)
+	msgfmt -c -o $@ $*.po

--- a/po/ja.po
+++ b/po/ja.po
@@ -1,0 +1,68 @@
+# Japanese translations for kano-vnc package.
+# Copyright (C) 2016 Kano Computing Ltd.
+# This file is distributed under the same license as the kano-vnc package.
+# Choppin Antoine <antoine@japonophile.com>, 2016.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: kano-vnc\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2016-06-12 16:51+0900\n"
+"PO-Revision-Date: 2016-06-12 16:26+0900\n"
+"Last-Translator: Choppin Antoine <antoine@japonophile.com>\n"
+"Language-Team: Japanese\n"
+"Language: ja\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=1; plural=0;\n"
+
+#: ../bin/kano-vnc:67
+msgid "The VNC Server was enabled"
+msgstr "VNCサーバーを有効にしました"
+
+#: ../bin/kano-vnc:67
+#, sh-format
+msgid ""
+"Hostname is $HOSTNAME.local$VNC_DISPLAY \n"
+"IP is $IP(TCP port 5900)\n"
+msgstr ""
+"ホスト名は$HOSTNAME.local$VNC_DISPLAYです。\n"
+"IPアドレスは$IP(TCPポート5900)\n"
+
+#: ../bin/kano-vnc:74
+msgid "Error!"
+msgstr "エラー！"
+
+#: ../bin/kano-vnc:74
+msgid "Something went wrong"
+msgstr "問題が発生しました"
+
+#: ../bin/kano-vnc:95
+msgid "The VNC Server was disabled"
+msgstr "VNCサーバーを無効にしました"
+
+#: ../bin/kano-vnc:110
+msgid "Create a VNC password"
+msgstr "VNCパスワードを作成してください"
+
+#: ../bin/kano-vnc:110
+msgid "Make it 6 to 8 characters long"
+msgstr "長さは6〜8英文字にして下さい"
+
+#: ../bin/kano-vnc:122
+msgid "You did not enter a valid password"
+msgstr "入力されたパスワードは無効です"
+
+#: ../bin/kano-vnc:122
+msgid "Try again"
+msgstr "もう一度入力して下さい"
+
+#: ../share/vncincoming:20
+msgid "VNC Connection"
+msgstr "VNC接続"
+
+#: ../share/vncincoming:21
+#, sh-format
+msgid "IP ${remote_ip} connected"
+msgstr "IP ${remote_ip}から接続されました"

--- a/share/vncglobals
+++ b/share/vncglobals
@@ -14,4 +14,4 @@ VNC_DISPLAY=":0"
 SHINCOMING="/usr/share/kano-vnc/vncincoming"
 VNCAPP="/usr/bin/x11vnc"
 
-VNC_CMDLINE="LANG=en_US $VNCAPP -rfbauth $PASS_FILE -avahi -display $VNC_DISPLAY -no6 -noipv6 -dontdisconnect -forever -shared -nolookup -ungrabboth -accept \"$SHINCOMING\" -N -bg"
+VNC_CMDLINE="$VNCAPP -rfbauth $PASS_FILE -avahi -display $VNC_DISPLAY -no6 -noipv6 -dontdisconnect -forever -shared -nolookup -ungrabboth -accept \"$SHINCOMING\" -N -bg"

--- a/share/vncglobals
+++ b/share/vncglobals
@@ -14,4 +14,4 @@ VNC_DISPLAY=":0"
 SHINCOMING="/usr/share/kano-vnc/vncincoming"
 VNCAPP="/usr/bin/x11vnc"
 
-VNC_CMDLINE="$VNCAPP -rfbauth $PASS_FILE -avahi -display $VNC_DISPLAY -no6 -noipv6 -dontdisconnect -forever -shared -nolookup -ungrabboth -accept \"$SHINCOMING\" -N -bg"
+VNC_CMDLINE="LANG=en_US $VNCAPP -rfbauth $PASS_FILE -avahi -display $VNC_DISPLAY -no6 -noipv6 -dontdisconnect -forever -shared -nolookup -ungrabboth -accept \"$SHINCOMING\" -N -bg"

--- a/share/vncincoming
+++ b/share/vncincoming
@@ -10,7 +10,7 @@
 #
 
 . gettext.sh
-export TEXTDOMAIN="make-snake"
+export TEXTDOMAIN="kano-vnc"
 
 notification_pipe="$HOME/.kano-notifications.fifo"
 remote_ip=$RFB_CLIENT_IP

--- a/share/vncincoming
+++ b/share/vncincoming
@@ -9,13 +9,16 @@
 # Return 0 to accept the remote client, anything different will kick him out.
 #
 
+. gettext.sh
+export TEXTDOMAIN="make-snake"
+
 notification_pipe="$HOME/.kano-notifications.fifo"
 remote_ip=$RFB_CLIENT_IP
 
 if [ -p $notification_pipe ]; then
     # Prepare a Desktop notification message
-    title="VNC Connection"
-    byline="IP ${remote_ip} connected"
+    title="`gettext "VNC Connection"`"
+    byline="`eval_gettext "IP \\\${remote_ip} connected"`"
     image="/usr/share/kano-vnc/notification.png"
     sound="/usr/share/kano-media/sounds/kano_open_app.wav"
     


### PR DESCRIPTION
These are the i18n hooks for kano-vnc, and the Japanese translation.

There was also an issue when parsing the output of ifconfig when the locale is not English, so I made sure to set LANG to en_US when running the command.
I also encountered some issue when trying to build the Debian package (formatting error in changelog), which I fixed too.

Tested on my Japanese Kano and the app is working fine.